### PR TITLE
Fix crusher initialization to start with only one crusher

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -189,7 +189,6 @@ public class Program
         caravan = new Caravan(refWidth, refHeight);
         sorter = new Sorter(caravan, StoneType.Earth, StoneType.Stone);
         sorters.Add(sorter);
-        crushers.Add(new Crusher(caravan, StoneType.Stone, StoneType.DenseStone));
         EarthPile earthPile = new EarthPile(caravan, 50, 50);
         Program.earthPile = earthPile;
 
@@ -220,6 +219,7 @@ public class Program
                 255f,
                 Names.GetUniqueName()
             ));
+            crushers.Add(new Crusher(caravan, StoneType.Stone, StoneType.DenseStone)); // P958e
         }
 
         int cols = refWidth / blockSize;


### PR DESCRIPTION
Move the initial crusher creation into the new game block in `Program.Main()`.

Remove the initial crusher creation from outside the if-else block in `Program.Main()`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/digera/yearn/pull/4?shareId=34b49027-eca9-4bed-8142-119ed6168ccf).